### PR TITLE
ci(ghactions): init GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: Continuous builds
+
+on:
+  push:
+    branches: [ master, development ]
+  pull_request:
+    branches: [ master, development ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.7, 3.8, 3.9]
+
+    steps:
+
+    - uses: actions/checkout@v2
+    - name: Set up Python  ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version:  ${{ matrix.python-version }}
+
+    - name: Print refs
+      run: |
+        echo "github.ref is: ${{ github.ref }}"
+        echo "github.base_ref is: ${{ github.base_ref }}"
+
+    - name: Install deps from development
+      if: ${{ github.ref == 'refs/heads/development' || github.base_ref == 'development' }}
+      run: |
+        echo "Using deps from development"
+        sed -i 's/@master/@development/' requirements-dev.txt
+
+    - name: Install deps from experimental
+      if: ${{ github.ref == 'refs/heads/experimental' || github.base_ref == 'experimental' }}
+      run: |
+        echo "Using deps from experimental"
+        sed -i 's/@master/@experimental/' requirements-dev.txt
+
+    - name: Install package
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-dev.txt
+        pip install .
+
+    - name: Run tests
+      run: |
+        ./test.sh
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        flake8 . --count --exit-zero --show-source --max-line-length=127 --statistics

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+scipy
+inspyred
+git+https://github.com/NeuralEnsemble/pyelectro.git@master#egg=pyelectro
+NEURON


### PR DESCRIPTION
Sets up GitHub actions.

Now that NEURON can be installed using `pip` directly, I didn't install `omv` and get that to install NEURON.