### PR TITLE
feat: add check for entity in analysis lists

### DIFF
--- a/neurotune/evaluators.py
+++ b/neurotune/evaluators.py
@@ -69,7 +69,7 @@ def normalised_cost_function(value, target, Q=None):
     value = float(value)
     target = float(target)
 
-    if Q == None:
+    if Q is None:
         if target != 0:
             Q = 7 / (300 * (target ** 2))
         else:
@@ -333,7 +333,7 @@ class IClampEvaluator(__Evaluator):
 
         print("target data path in evaluator:" + target_data_path)
 
-        if automatic == True:
+        if automatic is True:
             t, v_raw = analysis.load_csv_data(target_data_path)
             v = numpy.array(v_raw)
 
@@ -413,7 +413,7 @@ class IClampEvaluator(__Evaluator):
         # calculate max fitness value (TODO: there may be a more pythonic way to do this..)
         worst_cumulative_fitness = 0
         for target in target_dict.keys():
-            if target_weights == None:
+            if target_weights is None:
                 target_weight = 1
             else:
                 if target in target_weights.keys():
@@ -424,7 +424,7 @@ class IClampEvaluator(__Evaluator):
             worst_cumulative_fitness += target_weight
 
         # if we have 1 or 0 peaks we won't conduct any analysis
-        if data_analysis.analysable_data == False:
+        if data_analysis.analysable_data is False:
             print("Data is non-analysable")
             return worst_cumulative_fitness
 
@@ -436,7 +436,7 @@ class IClampEvaluator(__Evaluator):
                 target_value = target_dict[target]
                 cost = "?"
 
-                if target_weights == None:
+                if target_weights is None:
                     target_weight = 1
                 else:
                     if target in target_weights.keys():
@@ -555,7 +555,7 @@ class NetworkEvaluator(__Evaluator):
 
             target_value = target_dict[target]
 
-            if target_weights == None:
+            if target_weights is None:
                 target_weight = 1
             else:
                 if target in target_weights.keys():
@@ -856,7 +856,7 @@ class PointValueEvaluator(__Evaluator):
 
             target_value = target_dict[target]
 
-            if target_weights == None:
+            if target_weights is None:
                 target_weight = 1
             else:
                 if target in target_weights.keys():

--- a/neurotune/evaluators.py
+++ b/neurotune/evaluators.py
@@ -576,6 +576,18 @@ class NetworkEvaluator(__Evaluator):
                         value = "<<infinite value!>>"
                         inc = target_weight
                 else:
+                    # Check if any targets for the provided entity are included
+                    # in the analysis results. If not, something is wrong.
+                    valid = False
+                    entity = target.split("/")[0].split(":")[0]
+                    for atarget in data_analysis.analysis_results.keys():
+                        if entity in atarget:
+                            valid = True
+                            break
+
+                    if not valid:
+                        raise RuntimeError("No target values for entity {} were found in the analysis results.  Please check your target parameter strings.\nAll target parameters are: {}".format(entity, data_analysis.analysis_results.keys()))
+
                     value = (
                         "<<cannot be calculated! (only: %s; peak_threshold: %s)>>"
                         % (

--- a/neurotune/optimizers.py
+++ b/neurotune/optimizers.py
@@ -38,6 +38,13 @@ class __Optimizer(object):
         self.mutation_rate = mutation_rate
         self.seeds = seeds
 
+        # check that constraints are of equal lengths
+        assert (len(self.max_constraints) == len(self.min_constraints)), "Min ({}) and max ({}) constraint lists are not of equal size.".format(len(self.min_constraints), len(self.max_constraints))
+
+        # check that min constraints are always less than max constraints
+        for i in range(0, len(self.max_constraints)):
+            assert (self.min_constraints[i] <= self.max_constraints[i]), "Min constraint {} is larger than max constraint {}.".format(self.min_constraints[i], self.max_constraints[i])
+
     def uniform_random_chromosome(self, random, args):
         chromosome = []
         for lo, hi in zip(self.max_constraints, self.min_constraints):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501, E502, F403, F405


### PR DESCRIPTION
If no analysis targets are generated for an entity, throw an error.
This is usually because of an error in the parameter strings.

Fixes #19